### PR TITLE
another approach to consider

### DIFF
--- a/06-async-iterable-protocol/exercises/rickmorty.solution.js
+++ b/06-async-iterable-protocol/exercises/rickmorty.solution.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 export default function createCharactersPaginator () {
   let nextPage = 'https://rickandmortyapi.com/api/character'
   return {
-    [Symbol.asyncIterator]() { return this; },
+    [Symbol.asyncIterator] () { return this },
     async next () {
       if (nextPage === null) {
         return { done: true, value: undefined }

--- a/06-async-iterable-protocol/exercises/rickmorty.solution.js
+++ b/06-async-iterable-protocol/exercises/rickmorty.solution.js
@@ -3,20 +3,17 @@ import axios from 'axios'
 export default function createCharactersPaginator () {
   let nextPage = 'https://rickandmortyapi.com/api/character'
   return {
-    [Symbol.asyncIterator] () {
-      return {
-        async next () {
-          if (nextPage === null) {
-            return { done: true, value: undefined }
-          }
-
-          const resp = await axios.get(nextPage)
-          nextPage = resp.data.info.next
-
-          const pageData = resp.data.results.map((char) => char.name)
-          return { done: false, value: pageData }
-        }
+    [Symbol.asyncIterator]() { return this; },
+    async next () {
+      if (nextPage === null) {
+        return { done: true, value: undefined }
       }
+
+      const resp = await axios.get(nextPage)
+      nextPage = resp.data.info.next
+
+      const pageData = resp.data.results.map((char) => char.name)
+      return { done: false, value: pageData }
     }
   }
 }


### PR DESCRIPTION
This is the exact same solution as the 05-async-iterator-protocol solution, with just one line inserted:

```js
[Symbol.asyncIterator]() { return this; },
```

That line makes the *iterator* an *iterable* of itself, which is generally a good best practice for iterators anyway.

Here it simplifies this instead of having to create an additional layer of nesting.

**Note:** you already did this same trick for the synchronous iterator / iterable solution pairing.